### PR TITLE
Add example two - use dotenv for secret and chatCompletion API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 /tests/fixtures/date_adjustment/testing_output.csv
 /tests/testing_output.csv
 .venv/
+.env 
 
 # Unit test / coverage reports
 htmlcov/

--- a/ai_examples/example_two.py
+++ b/ai_examples/example_two.py
@@ -1,0 +1,49 @@
+import logging.config
+import os
+from os import path
+
+import openai
+from dotenv import load_dotenv
+
+load_dotenv
+
+log_config_path = path.join(path.dirname(path.abspath(__file__)), "logging.conf")
+logging.config.fileConfig(log_config_path)
+
+# Create logger
+logger = logging.getLogger("ai_examples")
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+# Use the openai ChatCompletion endpoint
+response = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Hello ChatGPT!"}],
+)
+
+# print structure
+# {
+#   "id": "chatcmpl-7xHKegP1246BrABCDE...xample",
+#   "object": "chat.completion",
+#   "created": 1694362332,
+#   "model": "gpt-3.5-turbo-0613",
+#   "choices": [
+#     {
+#       "index": 0,
+#       "message": {
+#         "role": "assistant",
+#         "content": "Nice to meet you too! How can I assist you today?"
+#       },
+#       "finish_reason": "stop"
+#     }
+#   ],
+#   "usage": {
+#     "prompt_tokens": 12,
+#     "completion_tokens": 13,
+#     "total_tokens": 25
+#   }
+# }
+print(response)
+
+# print the response
+print(response["choices"][0]["message"]["content"])


### PR DESCRIPTION
Added example_two.py

This uses the python_dotenv package to use the API secret, which is stored in a .env file that is never stored in source control (hence the .gitignore change)

example_two then goes on to create a message to chatGPT using the chatCompletion API, print the result structure and also the resulting message